### PR TITLE
Feat/us 10

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -16,6 +16,7 @@
 :root {
   --light-text-color: rgba(76, 39, 25, 1);
   --light-bg-bloc-color: rgba(248, 245, 202, 0.54);
+  --light-bg-bloc-color-100: rgba(248, 245, 202, 1);
   --light-border-bloc-color: rgba(76, 39, 25, 1);
 
   --font-family-body: "Open Sans", sans-serif;

--- a/client/src/components/WorldMap/WorldMap.css
+++ b/client/src/components/WorldMap/WorldMap.css
@@ -25,12 +25,13 @@
       grid: repeat(2, auto) repeat(2, 1fr);
     }
 
-    &:open::backdrop {
-      animation: backdrop-fade-in 0.5s ease-out forwards;
+    &::backdrop {
+      background: rgba(0, 0, 0, 0);
+      transition: background-color 0.5s ease-in-out;
     }
 
-    &::backdrop {
-      background: rgba(0, 0, 0, 0.5);
+    &:open::backdrop {
+      background-color: rgba(0, 0, 0, 0.5);
     }
 
     p {
@@ -78,6 +79,13 @@
 
     button {
       margin: 0.3rem;
+      background-color: var(--light-bg-bloc-color);
+      border: 1px solid var(--light-border-bloc-color);
+      border-radius: 4px;
+
+      &:hover {
+        background-color: var(--light-bg-bloc-color-100);
+      }
     }
   }
 }
@@ -85,33 +93,19 @@
 @keyframes fade-in {
   0% {
     opacity: 0;
-    display: none;
   }
 
   100% {
     opacity: 1;
-    display: block;
   }
 }
 
 @keyframes fade-out {
   0% {
     opacity: 1;
-    display: block;
   }
 
   100% {
     opacity: 0;
-    display: none;
-  }
-}
-
-@keyframes backdrop-fade-in {
-  0% {
-    background-color: rgb(0 0 0 / 0%);
-  }
-
-  100% {
-    background-color: rgb(0 0 0 / 100%);
   }
 }

--- a/client/src/components/WorldMap/WorldMap.css
+++ b/client/src/components/WorldMap/WorldMap.css
@@ -1,19 +1,117 @@
 .world-map-section {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: grid;
+  grid: repeat(2, auto) 1fr;
 
-  .map-container {
+  h3 {
+    grid-area: 1 / 1 / 2 / 2;
+    text-align: center;
+  }
+
+  dialog {
+    grid-area: 2 / 1 / 3 / 2;
+    place-self: center;
+    padding: 16px;
+    min-width: 240px;
+    color: var(--light-text-color);
+    background-color: var(--light-bg-bloc-color);
+    border: 1px solid var(--light-border-bloc-color);
+    border-radius: 16px;
+
+    animation: fade-out 0.5s ease-out;
+
+    &:open {
+      animation: fade-in 0.5s ease-out;
+      display: grid;
+      grid: repeat(2, auto) repeat(2, 1fr);
+    }
+
+    &:open::backdrop {
+      animation: backdrop-fade-in 0.5s ease-out forwards;
+    }
+
+    &::backdrop {
+      background: rgba(0, 0, 0, 0.5);
+    }
+
+    p {
+      padding: 16px;
+      font-size: 1.5rem;
+      font-weight: 500;
+      grid-area: 1 / 1 / 2 / 3;
+      place-self: center;
+    }
+
+    button {
+      padding: 4px 0;
+      width: 64px;
+      color: var(--light-text-color);
+      background-color: #fff;
+      border: 1px solid var(--light-border-bloc-color);
+      border-radius: 8px;
+
+      &:hover {
+        background-color: var(--light-bg-bloc-color-100);
+        opacity: 1;
+      }
+
+      &:nth-of-type(1) {
+        grid-area: 2 / 1 / 3 / 2;
+        place-self: center;
+      }
+
+      &:nth-of-type(2) {
+        grid-area: 2 / 2 / 3 / 3;
+        place-self: center;
+      }
+    }
+  }
+
+  .composable-map {
     max-height: 80vh;
-    border: 1px solid red;
+    grid-area: 2 / 1 / 3 / 2;
+    justify-self: center;
   }
 
   .controls {
-    position: relative;
-    bottom: 3rem;
+    grid-area: 2 / 1 / 3 / 2;
+    justify-self: center;
 
     button {
       margin: 0.3rem;
     }
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+    display: none;
+  }
+
+  100% {
+    opacity: 1;
+    display: block;
+  }
+}
+
+@keyframes fade-out {
+  0% {
+    opacity: 1;
+    display: block;
+  }
+
+  100% {
+    opacity: 0;
+    display: none;
+  }
+}
+
+@keyframes backdrop-fade-in {
+  0% {
+    background-color: rgb(0 0 0 / 0%);
+  }
+
+  100% {
+    background-color: rgb(0 0 0 / 100%);
   }
 }

--- a/client/src/components/WorldMap/WorldMap.tsx
+++ b/client/src/components/WorldMap/WorldMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState, useRef } from "react";
 import { useNavigate } from "react-router";
 import {
   ComposableMap,
@@ -33,7 +33,7 @@ const WorldMap = () => {
     setPosition(position);
   };
 
-  // Nav on click
+  // Nav on click + Popover
 
   const navigate = useNavigate();
 
@@ -42,16 +42,15 @@ const WorldMap = () => {
       ?.strArea;
   };
 
-  const dialog = document.querySelector("dialog");
-  const popoverText = document.querySelector(".popover-text");
-  let area: string | undefined;
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const popTextRef = useRef<HTMLParagraphElement>(null);
+  const [area, setArea] = useState<string | undefined>("");
+  const [countryName, setCountryName] = useState("");
 
   const handleClick = (geoName: string) => {
-    area = getAreaFromGeo(geoName);
-    if (popoverText) {
-      popoverText.innerHTML = `Chosen country : ${geoName}`;
-    }
-    area && dialog && dialog.showModal()
+    setArea(getAreaFromGeo(geoName));
+    setCountryName(geoName);
+    area && dialogRef.current && dialogRef.current.showModal()
   };
 
   return (
@@ -59,11 +58,11 @@ const WorldMap = () => {
       <p>
         Click, Cook, Travel : Discover the Flavors of the World with a click!
       </p>
-      <dialog>
+      <dialog ref={dialogRef}>
         <button
           type="button"
           onClick={() => {
-            if (dialog) dialog.close()
+            if (dialogRef.current) dialogRef.current.close()
           }}
         >
           Close
@@ -73,9 +72,8 @@ const WorldMap = () => {
             area && navigate(`/recipe-list/${area}`);
           }}>
           Travel !
-
         </button>
-        <p className="popover-text">Test modal</p>
+        <p ref={popTextRef}>Chosen country :  {countryName}</p>
       </dialog>
       <ComposableMap
         projection={mapFeatures.projection}

--- a/client/src/components/WorldMap/WorldMap.tsx
+++ b/client/src/components/WorldMap/WorldMap.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import {
   ComposableMap,
@@ -50,7 +50,7 @@ const WorldMap = () => {
   const handleClick = (geoName: string) => {
     setArea(getAreaFromGeo(geoName));
     setCountryName(geoName);
-    area && dialogRef.current && dialogRef.current.showModal()
+    area && dialogRef.current && dialogRef.current.showModal();
   };
 
   return (
@@ -63,15 +63,17 @@ const WorldMap = () => {
         <button
           type="button"
           onClick={() => {
-            if (dialogRef.current) dialogRef.current.close()
+            if (dialogRef.current) dialogRef.current.close();
           }}
         >
           Choose another
         </button>
-        <button type="button"
+        <button
+          type="button"
           onClick={() => {
             area && navigate(`/recipe-list/${area}`);
-          }}>
+          }}
+        >
           Travel now !
         </button>
       </dialog>

--- a/client/src/components/WorldMap/WorldMap.tsx
+++ b/client/src/components/WorldMap/WorldMap.tsx
@@ -55,25 +55,25 @@ const WorldMap = () => {
 
   return (
     <section className="world-map-section">
-      <p>
-        Click, Cook, Travel : Discover the Flavors of the World with a click!
-      </p>
+      <h3>
+        Click, Cook, Travel : Discover the flavors of the world with a click!
+      </h3>
       <dialog ref={dialogRef}>
+        <p ref={popTextRef}>{countryName}</p>
         <button
           type="button"
           onClick={() => {
             if (dialogRef.current) dialogRef.current.close()
           }}
         >
-          Close
+          Choose another
         </button>
         <button type="button"
           onClick={() => {
             area && navigate(`/recipe-list/${area}`);
           }}>
-          Travel !
+          Travel now !
         </button>
-        <p ref={popTextRef}>Chosen country :  {countryName}</p>
       </dialog>
       <ComposableMap
         projection={mapFeatures.projection}
@@ -81,7 +81,7 @@ const WorldMap = () => {
           scale: mapFeatures.scale,
           center: mapFeatures.center,
         }}
-        className="map-container"
+        className="composable-map"
       >
         <ZoomableGroup
           zoom={position.zoom}

--- a/client/src/components/WorldMap/WorldMap.tsx
+++ b/client/src/components/WorldMap/WorldMap.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import {
   ComposableMap,
@@ -42,9 +42,16 @@ const WorldMap = () => {
       ?.strArea;
   };
 
+  const dialog = document.querySelector("dialog");
+  const popoverText = document.querySelector(".popover-text");
+  let area: string | undefined;
+
   const handleClick = (geoName: string) => {
-    const area = getAreaFromGeo(geoName);
-    area && navigate(`/recipe-list/${area}`);
+    area = getAreaFromGeo(geoName);
+    if (popoverText) {
+      popoverText.innerHTML = `Chosen country : ${geoName}`;
+    }
+    area && dialog && dialog.showModal()
   };
 
   return (
@@ -52,7 +59,24 @@ const WorldMap = () => {
       <p>
         Click, Cook, Travel : Discover the Flavors of the World with a click!
       </p>
+      <dialog>
+        <button
+          type="button"
+          onClick={() => {
+            if (dialog) dialog.close()
+          }}
+        >
+          Close
+        </button>
+        <button type="button"
+          onClick={() => {
+            area && navigate(`/recipe-list/${area}`);
+          }}>
+          Travel !
 
+        </button>
+        <p className="popover-text">Test modal</p>
+      </dialog>
       <ComposableMap
         projection={mapFeatures.projection}
         projectionConfig={{

--- a/client/src/components/WorldMap/data/worldMapData.tsx
+++ b/client/src/components/WorldMap/data/worldMapData.tsx
@@ -58,7 +58,7 @@ export const mapFeatures: FeatureProps = {
   projection: availableProjections[10] as ProjectionProps,
   stroke: "#000",
   strokeWidth: 0.2,
-  notAvailableColor: "#EEE",
-  availableColor: "lightblue",
-  availableColorHover: "pink",
+  notAvailableColor: "#F5F5F5",
+  availableColor: "rgba(248, 245, 202, 1)",
+  availableColorHover: "rgba(76, 39, 25, 0.4)",
 };


### PR DESCRIPTION
## US-10 - Add popover on country click to confirm selection

### Description

This PR implements the following feature:  
As a user, when I click on a country on the world map, I want a pop-up (popover) to appear to confirm my selection.

### What has been done

- Added a `Popover` component that appears when a country is clicked on the map.
- Removed the tooltip behavior (tooltip component still exists, just not used for now).
- Updated the styles for the map, zoom icons, and the new popover component.
- Replaced direct DOM manipulation with the `useRef` hook for a cleaner implementation.

### Desktop behavior

✅ Popover appears correctly on country click  
✅ Map, zoom controls, and popover have consistent styling  

### To be done next

- Improve/adjust country selection logic for mobile version
- Potential future improvements:
  - Add a dropdown list to select countries (in addition to map)
  - Implement smoother zoom in/out transitions
  - Allow direct focus on a continent
  - Reintroduce tooltip on hover (desktop)
  - Customize the message shown in the popover depending on the selected country