### PR TITLE
US-22 - Improve visual style of map and mobile navigation

### DIFF
--- a/client/src/components/WorldMap/WorldMap.css
+++ b/client/src/components/WorldMap/WorldMap.css
@@ -1,11 +1,12 @@
 .world-map-section {
   display: grid;
   grid: repeat(3, auto) / 1fr;
-  min-height: calc(100vh - 68.55px - 52.55px);
+  min-height: calc(100vh - 65px - 58.1px);
 
   h3 {
     text-align: center;
     height: fit-content;
+    margin: 16px auto;
   }
 
   .static-map {
@@ -156,6 +157,10 @@
       max-height: 80vh;
       grid-area: 2 / 1 / 3 / 2;
       justify-self: center;
+
+      .country-on-map {
+        transition: 0.5s;
+      }
     }
 
     .controls {
@@ -168,6 +173,7 @@
         background-color: var(--light-bg-bloc-color);
         border: 1px solid var(--light-border-bloc-color);
         border-radius: 4px;
+        cursor: pointer;
 
         &:hover {
           background-color: var(--light-bg-bloc-color-100);
@@ -176,8 +182,8 @@
     }
   }
 
-  @media screen and (min-width: 992px) {
-    min-height: calc(100vh - 68.55px - 57.35px);
+  @media screen and (min-width: 600px) {
+    min-height: calc(100vh - 98px - 58.1px);
   }
 }
 

--- a/client/src/components/WorldMap/WorldMap.tsx
+++ b/client/src/components/WorldMap/WorldMap.tsx
@@ -228,7 +228,7 @@ const WorldMap = () => {
                   <Geography
                     key={geo.rsmKey}
                     geography={geo}
-                    className={geo.properties.name}
+                    className={`${geo.properties.name} country-on-map`}
                     stroke={mapFeatures.stroke}
                     strokeWidth={mapFeatures.strokeWidth}
                     style={{

--- a/client/src/components/WorldMap/data/worldMapData.tsx
+++ b/client/src/components/WorldMap/data/worldMapData.tsx
@@ -139,5 +139,5 @@ export const mapFeatures: FeatureProps = {
   strokeWidth: 0.2,
   notAvailableColor: "#F5F5F5",
   availableColor: "rgba(248, 245, 202, 1)",
-  availableColorHover: "rgba(76, 39, 25, 0.4)",
+  availableColorHover: "rgba(76, 39, 25, 0.8)",
 };


### PR DESCRIPTION
##  US-22 - Improve visual style of map and mobile navigation

###  Description
US-22- As a user, I want the map and its associated mobile navigation to look visually pleasing.

All the tasks from the checklist have been completed to enhance the user interface and interactivity of the map.

### ✅ What has been done
- [x] Changed hover color for countries on desktop view.
- [x] Move the `h3` title (too close to the header)
- [x] Added a smooth transition effect on country hover in desktop mode.
- [x] Updated the cursor style on map zoom buttons to improve affordance.

### Future improvements
- Add a transition on the appearance of the dropdown (Combobox popover) in mobile view.
- Make the zoom behavior on the map smoother and less abrupt.
- Fix a minor bug with selecting France — currently only selectable via Corsica or French Guiana.